### PR TITLE
Feature: Flip bits in the binary column by clicking them

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -50,6 +50,11 @@ td {
 
 .bin {
   color: lime;
+  text-align: right;
+}
+
+.bin b.bit {
+  cursor: pointer;
 }
 
 .hex {

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,5 +1,6 @@
 import illustrator from "./illustrator/illustrator.js";
 import input from "./input/input.js";
+import bitFlipper from "./bit-flipper/bit-flipper.js";
 const elHtml = document.documentElement;
 const elHeaders = document.getElementById("headers");
 const elOutput = document.getElementById("output");
@@ -17,25 +18,26 @@ function rerender(text) {
     let ouputMarkup = "";
     for (const char of text) {
         const codePoint = char.codePointAt(0);
-        ouputMarkup += illustrator.createMarkup(char, codePoint);
+        ouputMarkup += illustrator.createMarkup(codePoint);
     }
     elOutput.innerHTML = ouputMarkup;
 }
 function renderPushedInput(char) {
     const template = document.createElement("template");
     const codePoint = char.codePointAt(0);
-    var markup = illustrator.createMarkup(char, codePoint);
-    template.innerHTML = markup;
+    template.innerHTML = illustrator.createMarkup(codePoint);
+    ;
     elOutput.appendChild(template.content);
 }
 function renderFromHex(hex) {
     const codePoint = parseInt(hex, 16);
-    elOutput.innerHTML = illustrator.createMarkup(`&#x${hex}`, codePoint);
+    elOutput.innerHTML = illustrator.createMarkup(codePoint);
 }
 window.addEventListener("load", () => {
     const elForm = document.getElementById("frmInput");
     const elInput = document.getElementById("txtInput");
     input.setupUI(elInput, elForm);
+    bitFlipper.setupUI(elOutput);
     elHtml.addEventListener(input.events.inputChanged, (e) => {
         const text = e.detail.input;
         rerender(text);

--- a/docs/js/bit-flipper/bit-flipper.js
+++ b/docs/js/bit-flipper/bit-flipper.js
@@ -1,0 +1,15 @@
+import illustrator from "../illustrator/illustrator.js";
+function setupUI(elOutput) {
+    elOutput.addEventListener("click", (e) => {
+        const elTarget = e.target;
+        if (elTarget.classList.contains("bit") && elTarget.dataset.power) {
+            const elRow = elTarget.closest("tr");
+            const elDec = elRow === null || elRow === void 0 ? void 0 : elRow.children[1];
+            const codePoint = parseInt(elDec.innerText) ^ (1 << parseInt(elTarget.dataset.power));
+            elRow.innerHTML = illustrator.createMarkup(codePoint, false);
+        }
+    });
+}
+export default {
+    setupUI
+};

--- a/docs/js/illustrator/illustrator.js
+++ b/docs/js/illustrator/illustrator.js
@@ -2,19 +2,27 @@ import codePointToUtf8 from "./codePointToUtf8.js";
 import octetsToMarkup from "./octetsToMarkup.js";
 import octetsToHex from "./octetsToHex.js";
 export default { createMarkup };
-function createMarkup(char, codePoint) {
-    const bin = codePoint.toString(2);
+function createMarkup(codePoint, includeRowTag = true) {
     const hex = codePoint.toString(16);
     const octets = codePointToUtf8(codePoint);
     const utf8OctetsMarkup = octetsToMarkup(octets);
     const utf8Hex = octetsToHex(octets);
-    return `
-    <tr>
-      <td class="glyph">${char}</td>
-      <td class="dec">${codePoint}</td>
-      <td class="hex"><a rel="nofollow noopener noreferrer" href="https://unicode-table.com/en/${hex}/">${hex}</a></td>
-      <td class="bin">${bin}</td>
-      <td>${utf8OctetsMarkup}</td>
-      <td class="hex">${utf8Hex}</td>
-    </tr>`;
+    const columnsMarkup = `
+    <td class="glyph">&#x${hex}</td>
+    <td class="dec">${codePoint}</td>
+    <td class="hex"><a rel="nofollow noopener noreferrer" href="https://unicode-table.com/en/${hex}/">${hex}</a></td>
+    <td class="bin">${codePointToBinaryMarkup(codePoint)}</td>
+    <td>${utf8OctetsMarkup}</td>
+    <td class="hex">${utf8Hex}</td>
+  `;
+    return includeRowTag ? `<tr>${columnsMarkup}</tr>` : columnsMarkup;
+}
+function codePointToBinaryMarkup(codePoint) {
+    return codePoint
+        .toString(2)
+        .split("")
+        .reverse()
+        .map((bit, index) => `<b class="bit" data-power="${index}" title="${Math.pow(2, index)}">${bit}</b>`)
+        .reverse()
+        .join("");
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import illustrator from "./illustrator/illustrator.js";
 import input from "./input/input.js";
+import bitFlipper from "./bit-flipper/bit-flipper.js";
 
 const elHtml = document.documentElement;
 const elHeaders = <HTMLElement>document.getElementById("headers");
@@ -20,7 +21,7 @@ function rerender(text: string): void {
 
   for(const char of text) {
     const codePoint = <number>char.codePointAt(0);
-    ouputMarkup += illustrator.createMarkup(char, codePoint);
+    ouputMarkup += illustrator.createMarkup(codePoint);
   }
 
   elOutput.innerHTML = ouputMarkup;
@@ -29,15 +30,14 @@ function rerender(text: string): void {
 function renderPushedInput(char: string) {
   const template = document.createElement("template");
   const codePoint = <number>char.codePointAt(0);
-  var markup = illustrator.createMarkup(char, codePoint);
 
-  template.innerHTML = markup;
+  template.innerHTML = illustrator.createMarkup(codePoint);;
   elOutput.appendChild(template.content);
 }
 
 function renderFromHex(hex: string) {
   const codePoint = parseInt(hex, 16);
-  elOutput.innerHTML = illustrator.createMarkup(`&#x${hex}`, codePoint);
+  elOutput.innerHTML = illustrator.createMarkup(codePoint);
 }
 
 window.addEventListener("load", () => {
@@ -45,6 +45,7 @@ window.addEventListener("load", () => {
   const elInput = <HTMLInputElement>document.getElementById("txtInput");
 
   input.setupUI(elInput, elForm);
+  bitFlipper.setupUI(elOutput);
 
   elHtml.addEventListener(input.events.inputChanged, (e: CustomEvent) => {
     const text = e.detail.input;

--- a/src/bit-flipper/bit-flipper.ts
+++ b/src/bit-flipper/bit-flipper.ts
@@ -1,0 +1,22 @@
+import illustrator from "../illustrator/illustrator.js";
+
+function setupUI(elOutput: HTMLElement) {
+  elOutput.addEventListener("click", (e: MouseEvent) => {
+    const elTarget = <HTMLElement>e.target;
+
+    if (elTarget.classList.contains("bit") && elTarget.dataset.power) {
+      // User flipped a bit in the binary column
+      const elRow = <HTMLTableRowElement>elTarget.closest("tr");
+      const elDec = <HTMLElement>elRow?.children[1];
+      // Resolve the new decimal value by applying a XOR mask where 1 is
+      // shifted {power} bits to the left (https://bit.ly/3MOF76F)
+      const codePoint = parseInt(elDec.innerText) ^ (1 << parseInt(elTarget.dataset.power));
+
+      elRow.innerHTML = illustrator.createMarkup(codePoint, false);
+    }
+  });
+}
+
+export default {
+  setupUI
+};

--- a/src/illustrator/illustrator.ts
+++ b/src/illustrator/illustrator.ts
@@ -8,30 +8,36 @@ import octetsToHex from "./octetsToHex.js";
  * Slightly leaky that this component is aware that the UI presents the illustration
  * in a table - but this is an application and not a lib:)
  *
- * @param char The character that is about to have its encoding illustrated.
- *             The code point could have been used to resolve the char/glyph
- *             but since the caller of this function already knows it we'll
- *             take a shortcut
  * @param codePoint The characters unicode codepoint (decimal)
  * @returns A string that contains markup for the illustration of the char
  *          and its encoding
  */
 export default { createMarkup };
 
-function createMarkup(char: string, codePoint: number): string {
-  const bin: string = codePoint.toString(2);
-  const hex: string = codePoint.toString(16);
+function createMarkup(codePoint: number, includeRowTag: boolean = true): string {
+  //const bin = codePoint.toString(2);
+  const hex = codePoint.toString(16);
   const octets: string[] = codePointToUtf8(codePoint);
   const utf8OctetsMarkup: string = octetsToMarkup(octets);
   const utf8Hex: string = octetsToHex(octets);
+  const columnsMarkup = `
+    <td class="glyph">&#x${hex}</td>
+    <td class="dec">${codePoint}</td>
+    <td class="hex"><a rel="nofollow noopener noreferrer" href="https://unicode-table.com/en/${hex}/">${hex}</a></td>
+    <td class="bin">${codePointToBinaryMarkup(codePoint)}</td>
+    <td>${utf8OctetsMarkup}</td>
+    <td class="hex">${utf8Hex}</td>
+  `;
 
-  return `
-    <tr>
-      <td class="glyph">${char}</td>
-      <td class="dec">${codePoint}</td>
-      <td class="hex"><a rel="nofollow noopener noreferrer" href="https://unicode-table.com/en/${hex}/">${hex}</a></td>
-      <td class="bin">${bin}</td>
-      <td>${utf8OctetsMarkup}</td>
-      <td class="hex">${utf8Hex}</td>
-    </tr>`;
+  return includeRowTag ? `<tr>${columnsMarkup}</tr>` : columnsMarkup;
+}
+
+function codePointToBinaryMarkup(codePoint: number): string {
+  return codePoint
+    .toString(2)
+    .split("")
+    .reverse() // Reverse so index of .map() matches the power of 2
+    .map((bit, index) => `<b class="bit" data-power="${index}" title="${Math.pow(2, index)}">${bit}</b>`)
+    .reverse()
+    .join("");
 }


### PR DESCRIPTION
In this PR:

- [x] Flip bits in the binary column

Not in this PR:

1. Update input text when bits are flipped
1. Ability to add more bits

Updating the text in the input field is very tricky since one emoji some times is made up of several code points (via use of Zero Width Joiner etc). So the text in the input field will not match the code points that are illustrated.

There's also the edge case when the user types in a new char at the end of the current string. In that case the UI will currently only add the illustration of that code point at the end of the output table and the string in the text input will not match what is shown in the output. But if the user adds (or deletes) a char in the middle of the input field, all output will be re-rendered and the output will match the input text. This behaviour is a bit inconsistent but deemed good enough right now.

The basic approach to this feature is: if you decide to flip bits you take on the role of a cosmic ray and the UI can only try its best to handle your actions🙂

This is what this feature looks like:
![flippin-bits](https://user-images.githubusercontent.com/452261/166692761-bb7168b5-2996-4842-ab73-c442afbe3d0f.gif)

Closes #8