### PR TITLE
Allow arbitrary number of Unicode code point escapes

### DIFF
--- a/docs/js/input/customEvents.js
+++ b/docs/js/input/customEvents.js
@@ -1,5 +1,3 @@
 export default class EventNames {
 }
 EventNames.inputChanged = "inputchanged";
-EventNames.inputPushed = "inputpushed";
-EventNames.hexInput = "hexinput";

--- a/docs/js/input/scanner.js
+++ b/docs/js/input/scanner.js
@@ -1,0 +1,45 @@
+export default {
+    scan
+};
+const unicodeEscSeqPrefix = ["\\", "u", "{"];
+const hexRange = /([0-9A-F])/i;
+function scan(incoming) {
+    let codePoints = [];
+    const iterator = incoming[Symbol.iterator]();
+    var chr = iterator.next();
+    while (!chr.done) {
+        if (chr.value !== unicodeEscSeqPrefix[0])
+            codePoints.push(chr.value.codePointAt(0));
+        else
+            codePoints = codePoints.concat(maybeResolveCodePointFromEscSeq(iterator));
+        chr = iterator.next();
+    }
+    return codePoints;
+}
+function maybeResolveCodePointFromEscSeq(iterator) {
+    let i = 0;
+    const codePoints = [92];
+    const hex = [];
+    while (true) {
+        var chr = iterator.next();
+        i++;
+        if (chr.done)
+            return codePoints;
+        codePoints.push(chr.value.codePointAt(0));
+        if (i < 3 && chr.value != unicodeEscSeqPrefix[i])
+            return codePoints;
+        if (i === 3 && hexRange.test(chr.value) === false)
+            return codePoints;
+        if (i >= 3 && i <= 9) {
+            if (chr.value === "}") {
+                return [parseInt(hex.join(""), 16)];
+            }
+            if (!hexRange.test(chr.value))
+                return codePoints;
+            hex.push(chr.value);
+        }
+        else if (i > 9) {
+            return codePoints;
+        }
+    }
+}

--- a/docs/js/output/bitFlipper.js
+++ b/docs/js/output/bitFlipper.js
@@ -12,13 +12,11 @@ function setupUI(elOutput) {
             const elDec = elRow === null || elRow === void 0 ? void 0 : elRow.children[1];
             const codePoint = parseInt(elDec.innerText) ^ (1 << parseInt(elTarget.dataset.power));
             elRow.innerHTML = createMarkup(codePoint, false);
-            let hexCodePoints = [];
-            elOutput.querySelectorAll("[data-hex]").forEach((elHex) => {
-                hexCodePoints.push(parseInt(elHex.dataset["hex"], 16));
-            });
+            const rowIndex = Array.from(elRow.parentNode.children).indexOf(elRow);
             elHtml.dispatchEvent(new CustomEvent(events.bitFlipped, {
                 detail: {
-                    hexCodePoints
+                    rowIndex,
+                    codePoint
                 }
             }));
         }

--- a/docs/js/output/output.js
+++ b/docs/js/output/output.js
@@ -8,18 +8,12 @@ const elLegend = document.getElementById("legend");
 export default { setupUI };
 function setupUI() {
     elHtml.addEventListener(input.events.inputChanged, (e) => {
-        rerender(e.detail.input);
-    });
-    elHtml.addEventListener(input.events.inputPushed, (e) => {
-        renderPushedInput(e.detail.pushedChar);
-    });
-    elHtml.addEventListener(input.events.hexInput, (e) => {
-        renderFromHex(e.detail.hex);
+        rerender(e.detail.codePoints);
     });
     bitFlipper.setupUI(elOutput);
 }
-function rerender(text) {
-    if (text.length === 0) {
+function rerender(codePoints) {
+    if (codePoints.length === 0) {
         elHeaders.classList.add("hide");
         elLegend.classList.add("hide");
     }
@@ -28,8 +22,7 @@ function rerender(text) {
         elLegend.classList.remove("hide");
     }
     let ouputMarkup = "";
-    for (const char of text) {
-        const codePoint = char.codePointAt(0);
+    for (const codePoint of codePoints) {
         ouputMarkup += createMarkup(codePoint);
     }
     elOutput.innerHTML = ouputMarkup;
@@ -40,8 +33,4 @@ function renderPushedInput(char) {
     template.innerHTML = createMarkup(codePoint);
     ;
     elOutput.appendChild(template.content);
-}
-function renderFromHex(hex) {
-    const codePoint = parseInt(hex, 16);
-    elOutput.innerHTML = createMarkup(codePoint);
 }

--- a/src/input/customEvents.ts
+++ b/src/input/customEvents.ts
@@ -3,8 +3,6 @@
 declare global {
   interface HTMLElementEventMap {
     inputchanged: CustomEvent,
-    inputpushed: CustomEvent,
-    hexinput: CustomEvent,
   }
 }
 
@@ -17,10 +15,4 @@ declare global {
 export default class EventNames {
   // Cue for the UI to rerender
   public static readonly inputChanged = "inputchanged";
-
-  // Cue for the UI to tuck on a row at the end of the table
-  public static readonly inputPushed = "inputpushed";
-
-  // Input is Unicode code point escape sequence (ie "\u{FEFF}")
-  public static readonly hexInput = "hexinput";
 }

--- a/src/input/scanner.ts
+++ b/src/input/scanner.ts
@@ -1,0 +1,64 @@
+export default {
+  scan
+}
+
+const unicodeEscSeqPrefix = ["\\", "u", "{"];
+const hexRange = /([0-9A-F])/i;
+
+function scan(incoming: string): number[] {
+  let codePoints: number[] = [];
+
+  const iterator = incoming[Symbol.iterator]();
+  var chr = iterator.next();
+
+  while (!chr.done) {
+    if (chr.value !== unicodeEscSeqPrefix[0])
+      codePoints.push(<number>chr.value.codePointAt(0));
+    else
+      codePoints = codePoints.concat(maybeResolveCodePointFromEscSeq(iterator));
+
+    chr = iterator.next();
+  }
+
+  return codePoints;
+}
+
+function maybeResolveCodePointFromEscSeq(iterator: IterableIterator<string>): number[] {
+  let i = 0;
+  const codePoints = [92]; // 92 = CodePoint of '\'
+  const hex: string[] = [];
+
+  while(true) {
+    var chr = iterator.next(); i++;
+
+    if (chr.done)
+      return codePoints;
+
+    codePoints.push(<number>chr.value.codePointAt(0));
+
+    if (i < 3 && chr.value != unicodeEscSeqPrefix[i])
+      // Not a unicode code point escape, first 3 chars must be '\u{'
+      return codePoints;
+
+    if (i === 3 && hexRange.test(chr.value) === false)
+      // Not a unicode code point escape, 4th char must be hex digit
+      return codePoints;
+
+    if (i >= 3 && i <= 9) {
+      if (chr.value === "}") {
+        // End of unicode code point escape, resolve hex code point
+        return [parseInt(hex.join(""), 16)];
+      }
+
+      if (!hexRange.test(chr.value))
+        // Not a unicode code point escape
+        return codePoints;
+
+      // Finally, a hex digit!
+      hex.push(chr.value);
+    } else if (i > 9) {
+      // Using more than 6 hex digits is not supported
+      return codePoints;
+    }
+  }
+}

--- a/src/input/scanner.ts
+++ b/src/input/scanner.ts
@@ -1,19 +1,20 @@
-export default {
-  scan
-}
-
 const unicodeEscSeqPrefix = ["\\", "u", "{"];
 const hexRange = /([0-9A-F])/i;
 
-function scan(incoming: string): number[] {
-  let codePoints: number[] = [];
+export type Token = {
+  codePoint: number,
+  sourceIsEscSeq: boolean
+}
+
+export function scan(incoming: string): Token[] {
+  let codePoints: Token[] = [];
 
   const iterator = incoming[Symbol.iterator]();
   var chr = iterator.next();
 
   while (!chr.done) {
     if (chr.value !== unicodeEscSeqPrefix[0])
-      codePoints.push(<number>chr.value.codePointAt(0));
+      codePoints.push({codePoint: <number>chr.value.codePointAt(0), sourceIsEscSeq: false});
     else
       codePoints = codePoints.concat(maybeResolveCodePointFromEscSeq(iterator));
 
@@ -23,7 +24,7 @@ function scan(incoming: string): number[] {
   return codePoints;
 }
 
-function maybeResolveCodePointFromEscSeq(iterator: IterableIterator<string>): number[] {
+function maybeResolveCodePointFromEscSeq(iterator: IterableIterator<string>): Token[] {
   let i = 0;
   const codePoints = [92]; // 92 = CodePoint of '\'
   const hex: string[] = [];
@@ -32,33 +33,33 @@ function maybeResolveCodePointFromEscSeq(iterator: IterableIterator<string>): nu
     var chr = iterator.next(); i++;
 
     if (chr.done)
-      return codePoints;
+      return codePoints.map(x => ({codePoint: x, sourceIsEscSeq: false}));
 
     codePoints.push(<number>chr.value.codePointAt(0));
 
     if (i < 3 && chr.value != unicodeEscSeqPrefix[i])
       // Not a unicode code point escape, first 3 chars must be '\u{'
-      return codePoints;
+      return codePoints.map(x => ({codePoint: x, sourceIsEscSeq: false}));
 
     if (i === 3 && hexRange.test(chr.value) === false)
       // Not a unicode code point escape, 4th char must be hex digit
-      return codePoints;
+      return codePoints.map(x => ({codePoint: x, sourceIsEscSeq: false}));
 
     if (i >= 3 && i <= 9) {
       if (chr.value === "}") {
         // End of unicode code point escape, resolve hex code point
-        return [parseInt(hex.join(""), 16)];
+        return [{codePoint: parseInt(hex.join(""), 16), sourceIsEscSeq: true}];
       }
 
       if (!hexRange.test(chr.value))
         // Not a unicode code point escape
-        return codePoints;
+        return codePoints.map(x => ({codePoint: x, sourceIsEscSeq: false}));
 
       // Finally, a hex digit!
       hex.push(chr.value);
     } else if (i > 9) {
       // Using more than 6 hex digits is not supported
-      return codePoints;
+      return codePoints.map(x => ({codePoint: x, sourceIsEscSeq: false}));
     }
   }
 }

--- a/src/output/bitFlipper.ts
+++ b/src/output/bitFlipper.ts
@@ -18,19 +18,14 @@ function setupUI(elOutput: HTMLElement) {
       // Resolve the new decimal value by applying a XOR mask where 1 is
       // shifted {power} bits to the left (https://bit.ly/3MOF76F)
       const codePoint = parseInt(elDec.innerText) ^ (1 << parseInt(elTarget.dataset.power));
-
       elRow.innerHTML = createMarkup(codePoint, false);
 
-      let hexCodePoints: number[] = [];
-
-      elOutput.querySelectorAll("[data-hex]").forEach((elHex: Element) => {
-        hexCodePoints.push(parseInt(<string>(<HTMLElement>elHex).dataset["hex"], 16));
-      });
+      const rowIndex = Array.from((<HTMLElement>elRow.parentNode).children).indexOf(elRow);
 
       elHtml.dispatchEvent(new CustomEvent(events.bitFlipped, {
         detail: {
-          // The code points (as hex) in the output
-          hexCodePoints
+          rowIndex,
+          codePoint
         }
       }));
     }

--- a/src/output/output.ts
+++ b/src/output/output.ts
@@ -12,22 +12,14 @@ export default { setupUI };
 
 function setupUI() {
   elHtml.addEventListener(input.events.inputChanged, (e: CustomEvent) => {
-    rerender(e.detail.input);
-  });
-
-  elHtml.addEventListener(input.events.inputPushed, (e: CustomEvent) => {
-    renderPushedInput(e.detail.pushedChar);
-  });
-
-  elHtml.addEventListener(input.events.hexInput, (e: CustomEvent) => {
-    renderFromHex(e.detail.hex);
+    rerender(<number[]>e.detail.codePoints);
   });
 
   bitFlipper.setupUI(elOutput);
 }
 
-function rerender(text: string): void {
-  if (text.length === 0) {
+function rerender(codePoints: number[]): void {
+  if (codePoints.length === 0) {
     elHeaders.classList.add("hide");
     elLegend.classList.add("hide")
   } else {
@@ -37,8 +29,7 @@ function rerender(text: string): void {
 
   let ouputMarkup = "";
 
-  for(const char of text) {
-    const codePoint = <number>char.codePointAt(0);
+  for(const codePoint of codePoints) {
     ouputMarkup += createMarkup(codePoint);
   }
 
@@ -51,9 +42,4 @@ function renderPushedInput(char: string) {
 
   template.innerHTML = createMarkup(codePoint);;
   elOutput.appendChild(template.content);
-}
-
-function renderFromHex(hex: string) {
-  const codePoint = parseInt(hex, 16);
-  elOutput.innerHTML = createMarkup(codePoint);
 }


### PR DESCRIPTION
In this PR:

- [x] Scan input string to allow arbitrary occurrences of Unicode code point escapes
- [x] Remove concept of being in "hex mode"
- [x] Adjust bit flippin logic to the removal of "hex mode"

Closes #11 

## Screenshots

<img width="801" alt="image" src="https://user-images.githubusercontent.com/452261/190898147-6e242a63-be6e-45c8-8e44-449c801c521e.png">
